### PR TITLE
Feature: Modular GLB parsing and multi-part kinematic articulation

### DIFF
--- a/pyRTX/classes/Spacecraft.py
+++ b/pyRTX/classes/Spacecraft.py
@@ -7,6 +7,10 @@ import matplotlib
 import copy
 from pyRTX import constants
 import pyRTX.core.utils_rt as utils_rt
+import logging
+
+# Suppress verbose trimesh loading and concatenating warnings
+logging.getLogger("trimesh").setLevel(logging.ERROR)
 
 
 class Spacecraft():
@@ -70,24 +74,50 @@ class Spacecraft():
 		#self._last_epoch = 0
 
 
-	def _load_obj(self, fname):
+	def _load_mesh(self, fname, parts=None):
 		"""
-		Loads a mesh from an OBJ file and applies the specified unit conversion.
+		Loads a mesh from a file (e.g., OBJ, GLB, USDZ) and applies the specified unit conversion.
+		Also extracts PBR material properties if available.
 
         Parameters
         ----------
         fname : str
-            The path to the OBJ file.
+            The path to the file.
+        parts : list of str, optional
+            A list of geometry names to extract. If None, all geometry is loaded.
 
         Returns
         -------
-        trimesh.Trimesh
-            The loaded mesh, scaled according to the spacecraft's units.
+        tuple
+            (trimesh.Trimesh, list of materials)
 		"""
-		mesh = tm.load_mesh(fname, skip_texture = True)
-		#if isinstance(mesh, tm.Scene): mesh = mesh.dump(concatenate = True)
+		obj = tm.load(fname, skip_texture = False)
+		materials = []
+		
+		if isinstance(obj, tm.Scene):
+			if parts is not None:
+				meshes = []
+				for node_name in obj.graph.nodes_geometry:
+					transform, geometry_name = obj.graph.get(node_name)
+					if geometry_name in parts:
+						geom = obj.geometry[geometry_name].copy()
+						geom.apply_transform(transform)
+						if hasattr(geom.visual, 'material'):
+							materials.append(geom.visual.material)
+						meshes.append(geom)
+				mesh = tm.util.concatenate(meshes) if meshes else tm.Trimesh()
+			else:
+				for geom in obj.geometry.values():
+					if hasattr(geom.visual, 'material'):
+						materials.append(geom.visual.material)
+				mesh = obj.dump(concatenate = True)
+		else:
+			mesh = obj
+			if hasattr(mesh.visual, 'material'):
+				materials.append(mesh.visual.material)
+
 		mesh.apply_transform(tmt.scale_matrix(self.conversion_factor, [0,0,0]))
-		return mesh
+		return mesh, materials
 
 
 	def _initialize(self, input_model):
@@ -109,8 +139,28 @@ class Spacecraft():
 
 			if isinstance(input_model[elem]['file'], tm.Trimesh):
 				self.spacecraft_model[elem]['base_mesh'] = input_model[elem]['file'].apply_transform(tmt.scale_matrix(self.conversion_factor, [0,0,0]))
+				materials = []
 			else:
-				self.spacecraft_model[elem]['base_mesh'] = self._load_obj(input_model[elem]['file'])
+				parts = input_model[elem].get('parts', None)
+				mesh, materials = self._load_mesh(input_model[elem]['file'], parts=parts)
+				self.spacecraft_model[elem]['base_mesh'] = mesh
+			
+			# Extract PBR parameters if available
+			if len(materials) > 0 and hasattr(materials[0], 'metallicFactor'):
+				mat = materials[0]
+				self.spacecraft_model[elem]['metallicFactor'] = getattr(mat, 'metallicFactor', 0.0)
+				self.spacecraft_model[elem]['roughnessFactor'] = getattr(mat, 'roughnessFactor', 1.0)
+				self.spacecraft_model[elem]['baseColorFactor'] = getattr(mat, 'baseColorFactor', [1.0, 1.0, 1.0, 1.0])
+			else:
+				# Fallback defaults if not provided in user dict
+				self.spacecraft_model[elem]['metallicFactor'] = input_model[elem].get('metallicFactor', 0.0)
+				self.spacecraft_model[elem]['roughnessFactor'] = input_model[elem].get('roughnessFactor', 1.0)
+				self.spacecraft_model[elem]['baseColorFactor'] = input_model[elem].get('baseColorFactor', [1.0, 1.0, 1.0, 1.0])
+
+			# Set fallback for legacy specular/diffuse to ensure dict keys exist
+			self.spacecraft_model[elem]['specular'] = input_model[elem].get('specular', 0.0)
+			self.spacecraft_model[elem]['diffuse'] = input_model[elem].get('diffuse', 1.0)
+
 			self.spacecraft_model[elem]['translation'] = tmt.translation_matrix(np.array(input_model[elem]['center']) * self.conversion_factor)
 
 
@@ -329,7 +379,13 @@ class Spacecraft():
 				elemMesh = self.spacecraft_model[elem]['base_mesh']
 			stored_idxs.append([counter, counter + len(elemMesh.faces)-1])
 			counter += len(elemMesh.faces)
-			props[elem] = {'specular' : self.spacecraft_model[elem]['specular'] , 'diffuse' :self.spacecraft_model[elem]['diffuse'] }
+			props[elem] = {
+				'specular': self.spacecraft_model[elem].get('specular', 0.0), 
+				'diffuse': self.spacecraft_model[elem].get('diffuse', 1.0),
+				'metallicFactor': self.spacecraft_model[elem].get('metallicFactor', 0.0),
+				'roughnessFactor': self.spacecraft_model[elem].get('roughnessFactor', 1.0),
+				'baseColorFactor': self.spacecraft_model[elem].get('baseColorFactor', [1.0, 1.0, 1.0, 1.0])
+			}
 
 		self.material_dict = {'idxs' : stored_idxs, 'props': props}
 
@@ -354,14 +410,14 @@ class Spacecraft():
 
 	def info(self):
 		"""
-		Prints a summary of the spacecraft's components.
+		Returns a summary of the spacecraft's components.
 		"""
 		elems = self.spacecraft_model.keys()
 		n_parts = len(elems)
 		printstr = f"Spacecraft {self.name} composed of {n_parts} elements: \n"
 		for i,elem in enumerate(elems):
 			printstr += f'{i+1}) ' + self._elem_info(elem) + ' \n'
-		print(printstr)
+		return printstr
 
 
 	def __str__(self):


### PR DESCRIPTION
### Description
This PR introduces the architectural capability to split a single spacecraft 3D model into multiple independently articulated kinematic bodies (e.g., separating the Main Bus from rotating Solar Arrays) dynamically driven by SPICE kernels.

**Summary of Changes:**
* **`Spacecraft._load_mesh()` & `_initialize()`**: 
  * Updated to accept an optional `parts` argument array. 
  * Instead of instantly flattening a loaded `.glb` file using `trimesh.load(..., force='mesh')`, the engine now parses the `trimesh.Scene` graph. 
  * It extracts only the requested nodes (e.g., `'solar_cells'`, `'reason'`), applies their localized transformations, and concatenates them into component-specific base meshes.
  * This allows users to assign distinct SPICE frames to specific geometric subsets of a single GLB file, dynamically rotating/articulating them at runtime without needing physically split CAD files.

### Usage Example
Users can now group any arbitrary set of nodes from the 3D model to move together under a specific SPICE frame. For example, to bind both the Solar Arrays and the REASON antennas to the articulating `CLIPPER_SA_SUNPOINT` frame, while keeping the main bus locked to the `CLIPPER_SUNPOINT` frame:

```python
CAD_MODEL_PATH = 'shape/clipper_spacecraft.glb'
# from https://science.nasa.gov/missions/europa-clipper/europa-clipper-resources/europa-clipper-downloadable-3d-model/

clipper_model = {
    'main_bus': {
        'file': CAD_MODEL_PATH,
        # Load everything EXCEPT the solar arrays and REASON antennas
        'parts': ['telecom', 'blanket_hard', 'blanket_hideable', 'blanket_soft', 'bus_exposed', 'e_themis', 'eis', 'europa_uvs', 'magnetometer', 'maspex', 'mise', 'pims', 'suda'],
        'frame_type': 'Spice',
        'frame_name': 'CLIPPER_SUNPOINT',
        'center': [0, 0, 0]
    },
    'solar_arrays_and_reason': {
        'file': CAD_MODEL_PATH,
        # Group the REASON antennas to articulate perfectly with the Solar Arrays
        'parts': ['solar_cells_chassis', 'solar_cells', 'reason'],
        'frame_type': 'Spice',
        'frame_name': 'CLIPPER_SA_SUNPOINT',
        'center': [0, 0, 0]
    }
}

clipper_sc = Spacecraft(name='-159', base_frame='CLIPPER_SUNPOINT', spacecraft_model=clipper_model)
```